### PR TITLE
Add loading indicator

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -73,12 +73,10 @@
   },
   "lint-staged": {
     "*.ts": [
-      "prettier --write",
       "vue-cli-service lint",
       "git add"
     ],
     "*.vue": [
-      "prettier --write",
       "vue-cli-service lint",
       "git add"
     ]

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,7 +1,7 @@
 <template>
-  <div id="app" class="font-sans">
+  <div id="app" class="font-sans flex flex-col min-h-screen">
     <SiteHeader />
-    <router-view />
+    <div class="flex-grow"><router-view /></div>
     <Footer />
   </div>
 </template>

--- a/client/src/components/Loader.vue
+++ b/client/src/components/Loader.vue
@@ -1,0 +1,45 @@
+<template>
+  <svg
+    width="38"
+    height="38"
+    viewBox="0 0 38 38"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <defs>
+      <linearGradient x1="8.042%" y1="0%" x2="65.682%" y2="23.865%" id="a">
+        <stop stop-color="#606F7B" stop-opacity="0" offset="0%" />
+        <stop stop-color="#606F7B" stop-opacity=".631" offset="63.146%" />
+        <stop stop-color="#606F7B" offset="100%" />
+      </linearGradient>
+    </defs>
+    <g fill="none" fill-rule="evenodd">
+      <g transform="translate(1 1)">
+        <path
+          d="M36 18c0-9.94-8.06-18-18-18"
+          id="Oval-2"
+          stroke="url(#a)"
+          stroke-width="2"
+        >
+          <animateTransform
+            attributeName="transform"
+            type="rotate"
+            from="0 18 18"
+            to="360 18 18"
+            dur="0.9s"
+            repeatCount="indefinite"
+          />
+        </path>
+        <circle fill="#fff" cx="36" cy="18" r="1">
+          <animateTransform
+            attributeName="transform"
+            type="rotate"
+            from="0 18 18"
+            to="360 18 18"
+            dur="0.9s"
+            repeatCount="indefinite"
+          />
+        </circle>
+      </g>
+    </g>
+  </svg>
+</template>

--- a/client/src/views/Product.vue
+++ b/client/src/views/Product.vue
@@ -57,9 +57,9 @@
             </div>
 
             <div class="w-1/2 h-12">
-              <button @click.native="addToCart(product.stock);">
+              <Button @click.native="addToCart(product.stock);">
                 Add to cart
-              </button>
+              </Button>
             </div>
           </div>
 

--- a/client/src/views/Shop.vue
+++ b/client/src/views/Shop.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
     <PageHeader>Shop</PageHeader>
+    <div v-if="$apollo.loading" class="my-20 text-center"><Loader /></div>
     <div
+      v-else
       class="container mx-auto my-10 md:my-12 px-4 flex flex-col md:flex-row"
     >
       <div class="md:w-1/5 mb-4 md:mb-0">
@@ -66,9 +68,10 @@ import Vue from "vue";
 import gql from "graphql-tag";
 import PageHeader from "@/components/PageHeader.vue";
 import Footer from "@/components/Footer.vue";
+import Loader from "@/components/Loader.vue";
 
 export default Vue.extend({
-  components: { PageHeader, Footer },
+  components: { PageHeader, Footer, Loader },
   data() {
     return {
       products: [],


### PR DESCRIPTION
Summary
---
Products recently started to take a long time to load :( This pulls adds a loading indicator to the shop so the page still feels responsive while products load.

Closes #98 

# QA
- Go to `/shop`
- Assert that a loading indicator is displayed while products load