### PR TITLE
Add Admin header

### DIFF
--- a/client/cypress/integration/login.spec.js
+++ b/client/cypress/integration/login.spec.js
@@ -51,4 +51,12 @@ context("Login", () => {
     cy.wait(2000); // There must be a less brittle way to do this
     cy.location("pathname").should("eq", "/");
   });
+
+  it("displays message if user is already logged in", () => {
+    localStorage.setItem("user", "test-user");
+    localStorage.setItem("apollo-token", "test-token");
+    cy.visit("http://localhost:8080/login"); // Reload page after setting localStorage
+
+    cy.get("[data-test-id=logged-in]").should("be.visible");
+  });
 });

--- a/client/cypress/integration/logout.spec.js
+++ b/client/cypress/integration/logout.spec.js
@@ -1,0 +1,16 @@
+context("Login", () => {
+  beforeEach(() => {
+    localStorage.setItem("user", "{\"name\": \"Test\", \"isAdmin\": true}");
+    localStorage.setItem("apollo-token", "test-token");
+    cy.visit("http://localhost:8080/");
+  });
+
+
+  it("redirects to login page after clicking log out", () => {
+    cy.get("[data-test-id=admin-header]").should("be.visible");
+    cy.get("[data-test-id=log-out]").click();
+    cy.wait(2000); // There must be a less brittle way to do this
+    cy.location("pathname").should("eq", "/login");
+    cy.get("[data-test-id=admin-header]").should("not.exist");
+  });
+})

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,5 +1,6 @@
 <template>
   <div id="app" class="font-sans flex flex-col min-h-screen">
+    <AdminHeader />
     <SiteHeader />
     <div class="flex-grow"><router-view /></div>
     <Footer />
@@ -7,16 +8,18 @@
 </template>
 
 <script lang="ts">
+import AdminHeader from "@/components/AdminHeader.vue";
 import SiteHeader from "@/components/SiteHeader.vue";
 import Footer from "@/components/Footer.vue";
+import { getUser } from "./auth";
 
 export default {
-  components: { SiteHeader, Footer },
+  components: { AdminHeader, SiteHeader, Footer },
 };
 </script>
 
 <style>
-@import url("https://fonts.googleapis.com/css?family=Work+Sans:400,600,700");
+@import url("https://fonts.googleapis.com/css?family=Work+Sans:400,500,600,700");
 
 body {
   margin: 0;

--- a/client/src/auth.ts
+++ b/client/src/auth.ts
@@ -1,4 +1,4 @@
-import { onLogin, AUTH_TOKEN } from "./vue-apollo";
+import { AUTH_TOKEN, onLogin, onLogout } from "./vue-apollo";
 
 const USER_KEY = "user";
 
@@ -13,6 +13,11 @@ export function logIn(token: string, user: User, apolloClient: any) {
   localStorage.setItem(USER_KEY, JSON.stringify(user));
   // Apollo will save the token and use it to authorize all future requests
   onLogin(apolloClient, token);
+}
+
+export function logOut(apolloClient: any) {
+  localStorage.removeItem(USER_KEY);
+  onLogout(apolloClient);
 }
 
 export function isLoggedIn() {

--- a/client/src/auth.ts
+++ b/client/src/auth.ts
@@ -1,0 +1,31 @@
+import { onLogin, AUTH_TOKEN } from "./vue-apollo";
+
+const USER_KEY = "user";
+
+interface User {
+  name: string;
+  email: string;
+  isAdmin: boolean;
+}
+
+export function logIn(token: string, user: User, apolloClient: any) {
+  // Save user data in localStorage
+  localStorage.setItem(USER_KEY, JSON.stringify(user));
+  // Apollo will save the token and use it to authorize all future requests
+  onLogin(apolloClient, token);
+}
+
+export function isLoggedIn() {
+  return (
+    Boolean(localStorage.getItem(USER_KEY)) &&
+    Boolean(localStorage.getItem(AUTH_TOKEN))
+  );
+}
+
+export function getUser(): User | null {
+  if (isLoggedIn()) {
+    return JSON.parse(localStorage.getItem(USER_KEY) || "{}");
+  }
+
+  return null;
+}

--- a/client/src/components/AdminHeader.vue
+++ b/client/src/components/AdminHeader.vue
@@ -1,5 +1,9 @@
 <template>
-  <div v-if="user" class="bg-black text-sm text-grey-light font-medium p-3 flex">
+  <div
+    v-if="user"
+    data-test-id="admin-header"
+    class="bg-black text-sm text-grey-light font-medium p-3 flex"
+  >
     <span>Welcome, {{user.name}}</span>
     <div class="mx-auto" />
     <router-link to="/admin/orders" class="text-grey-light ml-5">
@@ -15,7 +19,11 @@
     >
       Accounts
     </router-link>
-    <button @click="logOut" class="text-grey-light ml-5 font-medium">
+    <button
+      data-test-id="log-out"
+      @click="logOut"
+      class="text-grey-light ml-5 font-medium"
+    >
       Log out
     </button>
   </div>

--- a/client/src/components/AdminHeader.vue
+++ b/client/src/components/AdminHeader.vue
@@ -1,0 +1,43 @@
+<template>
+  <div v-if="user" class="bg-black text-sm text-grey-light font-medium p-3 flex">
+    <span>Welcome, {{user.name}}</span>
+    <div class="mx-auto" />
+    <router-link to="/admin/orders" class="text-grey-light ml-5">
+      Orders
+    </router-link>
+    <router-link to="/admin/inventory" class="text-grey-light ml-5">
+      Inventory
+    </router-link>
+    <router-link
+      v-if="user.isAdmin"
+      to="/admin/accounts"
+      class="text-grey-light ml-5"
+    >
+      Accounts
+    </router-link>
+    <button @click="logOut" class="text-grey-light ml-5 font-medium">
+      Log out
+    </button>
+  </div>
+</template>
+
+<script>
+import Vue from "vue";
+import { getUser, logOut } from "../auth";
+
+export default Vue.extend({
+  data() {
+    return { user: null };
+  },
+  mounted() {
+    this.user = getUser();
+  },
+  methods: {
+    logOut() {
+      logOut(this.$apollo.provider.defaultClient);
+      // Redirect to Login page
+      window.location = "/login";
+    }
+  }
+})
+</script>

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -23,6 +23,7 @@
               Email
             </label>
             <input
+              :disabled="loading"
               id="email"
               name="email"
               type="email"
@@ -37,6 +38,7 @@
               Password
             </label>
             <input
+              :disabled="loading"
               id="password"
               name="password"
               type="password"
@@ -47,7 +49,10 @@
             />
           </div>
           <div class="flex flex-col items-stretch mt-12">
-            <Button data-test-id="login-button">Log in</Button>
+            <Button data-test-id="login-button" :disabled="loading">
+              <span v-if="loading">Loading...</span>
+              <span v-else>Log in</span>
+            </Button>
           </div>
         </form>
       </div>
@@ -60,7 +65,7 @@ import Vue from "vue";
 import gql from "graphql-tag";
 import PageHeader from "@/components/PageHeader.vue";
 import Button from "@/components/Button.vue";
-import { logIn, isLoggedIn } from "@/auth.ts";
+import { logIn, isLoggedIn } from "../auth";
 
 export default Vue.extend({
   components: { PageHeader, Button },
@@ -70,6 +75,7 @@ export default Vue.extend({
       email: "",
       password: "",
       isLoggedIn: false,
+      loading: false,
     };
   },
   mounted() {
@@ -77,6 +83,7 @@ export default Vue.extend({
   },
   methods: {
     logIn(event) {
+      this.loading = true;
       event.preventDefault();
       this.$apollo
         .mutate({
@@ -108,7 +115,10 @@ export default Vue.extend({
           // We use window.location instead of $router.push to trigger a page refresh
           // so any components that use localStorage get updated
         })
-        .catch(error => (this.error = error));
+        .catch(error => {
+          this.loading= false;
+          this.error = error;
+        });
     },
   },
 });

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -3,45 +3,54 @@
     <PageHeader>Login</PageHeader>
     <div class="max-w-xs mx-auto mt-16 mb-24">
       <div
-        v-if="error"
-        data-test-id="error"
-        class="p-4 text-red-darker leading-normal bg-red-lightest mb-8"
+        v-if="isLoggedIn"
+        data-test-id="logged-in"
+        class="text-black text-center"
       >
-        {{ error.message }}
+        You are already logged in.
       </div>
-      <form id="login-form" @submit="logIn">
-        <div class="mb-8">
-          <label for="email" class="inline-block font-semibold mb-2">
-            Email
-          </label>
-          <input
-            id="email"
-            name="email"
-            type="email"
-            v-model="email"
-            placeholder="bill@example.com"
-            class="w-full p-3 border border-grey"
-            required
-          />
+      <div v-else>
+        <div
+          v-if="error"
+          data-test-id="error"
+          class="p-4 text-red-darker leading-normal bg-red-lightest mb-8"
+        >
+          {{ error.message }}
         </div>
-        <div>
-          <label for="password" class="inline-block font-semibold mb-2">
-            Password
-          </label>
-          <input
-            id="password"
-            name="password"
-            type="password"
-            v-model="password"
-            placeholder="•••••"
-            class="w-full p-3 border border-grey"
-            required
-          />
-        </div>
-        <div class="flex flex-col items-stretch mt-12">
-          <Button data-test-id="login-button">Log in</Button>
-        </div>
-      </form>
+        <form id="login-form" @submit="logIn">
+          <div class="mb-8">
+            <label for="email" class="inline-block font-semibold mb-2">
+              Email
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              v-model="email"
+              placeholder="bill@example.com"
+              class="w-full p-3 border border-grey"
+              required
+            />
+          </div>
+          <div>
+            <label for="password" class="inline-block font-semibold mb-2">
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              v-model="password"
+              placeholder="•••••"
+              class="w-full p-3 border border-grey"
+              required
+            />
+          </div>
+          <div class="flex flex-col items-stretch mt-12">
+            <Button data-test-id="login-button">Log in</Button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 </template>
@@ -51,7 +60,7 @@ import Vue from "vue";
 import gql from "graphql-tag";
 import PageHeader from "@/components/PageHeader.vue";
 import Button from "@/components/Button.vue";
-import { onLogin } from "../vue-apollo";
+import { logIn, isLoggedIn } from "@/auth.ts";
 
 export default Vue.extend({
   components: { PageHeader, Button },
@@ -60,7 +69,11 @@ export default Vue.extend({
       error: null,
       email: "",
       password: "",
+      isLoggedIn: false,
     };
+  },
+  mounted() {
+    this.isLoggedIn = isLoggedIn();
   },
   methods: {
     logIn(event) {
@@ -84,13 +97,16 @@ export default Vue.extend({
             password: this.password,
           },
         })
-        .then(data => {
-          // Save user data in localStorage
-          localStorage.setItem("user", JSON.stringify(data.data.logIn.user));
-          // Apollo will save the token and use it to authorize all future requests
-          onLogin(this.$apollo.provider.defaultClient, data.data.logIn.token);
+        .then(({ data }) => {
+          logIn(
+            data.logIn.token,
+            data.logIn.user,
+            this.$apollo.provider.defaultClient,
+          );
           // Redirect to homepage
-          this.$router.push("/");
+          window.location = "/";
+          // We use window.location instead of $router.push to trigger a page refresh
+          // so any components that use localStorage get updated
         })
         .catch(error => (this.error = error));
     },

--- a/client/src/vue-apollo.ts
+++ b/client/src/vue-apollo.ts
@@ -9,7 +9,7 @@ import {
 Vue.use(VueApollo);
 
 // Name of the localStorage item
-const AUTH_TOKEN = "apollo-token";
+export const AUTH_TOKEN = "apollo-token";
 
 // Http endpoint
 const httpEndpoint =


### PR DESCRIPTION
## Summary
This pull adds the admin header for logged in users with links to all the admin pages and a log out button.

Closes #26 

### Package Changes
No changes

### Data Model Changes
No changes

### Known Issues
No known issues

## QA
- [x] Assert that admin header isn't visible when logged out
- [x] Log in (email: `bill@example.com`, password: `password)
- [x] Assert that admin header is now visible
- [x] Assert that links in admin header work as expected
- [x] Assert that log out directs you back to the login page and the admin header is not gone

### User Acceptance Tests
- [x] I updated the [UAT Spreadsheet](https://docs.google.com/spreadsheets/d/1-unNcLQL7Nr2V69aXBpQKMH-Uv7lJhNOD3K-V7wv5Ik/edit?usp=sharing "UAT Spreadsheet") with tests for all proposed feature in this PR.
