### PR TITLE
Add Accounts page

### DIFF
--- a/client/cypress/integration/accounts.spec.js
+++ b/client/cypress/integration/accounts.spec.js
@@ -1,0 +1,33 @@
+context("Accounts", () => {
+  beforeEach(() => {
+    // Must be logged in
+    cy.visit("http://localhost:8080/login");
+    cy.get("#email")
+      .type("bill@example.com")
+      .should("have.value", "bill@example.com");
+    cy.get("#password")
+      .type("password")
+      .should("have.value", "password");
+    cy.get("[data-test-id=login-button]")
+      .click()
+      .should(() => {
+        expect(localStorage.getItem("user")).to.exist;
+        expect(localStorage.getItem("apollo-token")).to.exist;
+      });
+    cy.visit("http://localhost:8080/admin/accounts");
+  });
+
+  it("can create and delete accounts", () => {
+    // Create account
+    cy.get("#name").type("Test User");
+    cy.get("#email").type("fake@email.com");
+    cy.get("#password").type("1234");
+    cy.get("#is-admin").check();
+    cy.get("[data-test-id=create-account]").click();
+    cy.get("[id='fake@email.com']").should("exist");
+
+    // Delete account
+    cy.get("[id='fake@email.com'] [data-test-id=delete]").click();
+    cy.get("[id='fake@email.com']").should("not.exist");
+  });
+});

--- a/client/src/views/Accounts.vue
+++ b/client/src/views/Accounts.vue
@@ -8,6 +8,7 @@
         <div
           v-for="(user, index) in users"
           :key="user.id"
+          :id="user.email"
           :class="[
             index !== users.length - 1 && 'border-b',
             'py-6 flex justify-between items-center',
@@ -30,6 +31,7 @@
             />
             <label :for="`is-admin-${user.id}`" class="ml-2 mr-6">Admin</label>
             <button
+              data-test-id="delete"
               @click="deleteUser(user.id);"
               class="px-3 py-2 text-sm bg-grey-light hover:bg-red hover:text-white"
             >
@@ -178,29 +180,38 @@ export default Vue.extend({
       });
     },
     createUser() {
-      this.$apollo.mutate({
-        mutation: gql`
-          mutation ($data: UserCreateInput!) {
-            createUser(data: $data) {
-              user {
-                id
-                name
-                email
-                isAdmin
+      this.$apollo
+        .mutate({
+          mutation: gql`
+            mutation ($data: UserCreateInput!) {
+              createUser(data: $data) {
+                user {
+                  id
+                  name
+                  email
+                  isAdmin
+                }
               }
             }
-          }
-        `,
-        variables: { data: this.newUser },
-        update: (store, { data: { createUser } }) => {
-          // Read the data from our cache for this query.
-          const data = store.readQuery({ query: USERS });
-          // Adds the user to the cache.
-          data.users.push(createUser.user);
-          // Writes the updated query to the cache.
-          store.writeQuery({ query: USERS, data });
-        },
-      });
+          `,
+          variables: { data: this.newUser },
+          update: (store, { data: { createUser } }) => {
+            // Read the data from our cache for this query.
+            const data = store.readQuery({ query: USERS });
+            // Adds the user to the cache.
+            data.users.push(createUser.user);
+            // Writes the updated query to the cache.
+            store.writeQuery({ query: USERS, data });
+          },
+        })
+        .then(() => {
+          this.newUser = {
+            name: "",
+            email: "",
+            password: "",
+            isAdmin: false,
+          };
+        });
     }
   },
 });

--- a/client/src/views/Accounts.vue
+++ b/client/src/views/Accounts.vue
@@ -22,13 +22,13 @@
           <!-- Only edit/delete other users -->
           <div v-if="currentUser.id !== user.id">
             <input
-              @change="updateIsAdmin(user.id, $event.target.checked)"
+              @change="updateIsAdmin(user.id, $event.target.checked);"
               type="checkbox"
-              id="is-admin"
-              name="is-admin"
+              :id="`is-admin-${user.id}`"
+              :name="`is-admin-${user.id}`"
               v-model="user.isAdmin"
-            >
-            <label for="is-admin" class="ml-2 mr-6">Admin</label>
+            />
+            <label :for="`is-admin-${user.id}`" class="ml-2 mr-6">Admin</label>
             <button
               @click="deleteUser(user.id);"
               class="px-3 py-2 text-sm bg-grey-light hover:bg-red hover:text-white"
@@ -39,6 +39,64 @@
           <div v-else class="text-grey-dark">(You)</div>
         </div>
       </div>
+      <div class="mt-6 bg-grey-lightest p-6">
+        <form @submit.prevent="createUser">
+          <div class="mb-8">
+            <label for="name" class="inline-block font-semibold mb-2">
+              Name
+            </label>
+            <input
+              id="name"
+              name="name"
+              type="text"
+              v-model="newUser.name"
+              placeholder="Bill Nye"
+              class="w-full p-3 border border-grey"
+              required
+            />
+          </div>
+          <div class="mb-8">
+            <label for="email" class="inline-block font-semibold mb-2">
+              Email
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              v-model="newUser.email"
+              placeholder="bill@example.com"
+              class="w-full p-3 border border-grey"
+              required
+            />
+          </div>
+          <div class="mb-8">
+            <label for="password" class="inline-block font-semibold mb-2">
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              v-model="newUser.password"
+              placeholder="•••••"
+              class="w-full p-3 border border-grey"
+              required
+            />
+          </div>
+          <div class="mb-8">
+            <input
+              type="checkbox"
+              id="is-admin"
+              name="is-admin"
+              v-model="newUser.isAdmin"
+            />
+            <label for="is-admin" class="ml-2 mr-6">Admin</label>
+          </div>
+          <div class="flex flex-col items-stretch">
+            <Button data-test-id="create-account">Create account</Button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 </template>
@@ -48,6 +106,7 @@ import gql from "graphql-tag";
 import Vue from "vue";
 import PageHeader from "@/components/PageHeader.vue";
 import Loader from "@/components/Loader.vue";
+import Button from "@/components/Button.vue";
 
 const USERS = gql`
   query users {
@@ -61,17 +120,23 @@ const USERS = gql`
 `;
 
 export default Vue.extend({
-  components: { PageHeader, Loader },
+  components: { PageHeader, Loader, Button },
   data() {
     return {
       users: [],
-      currentUser: null
+      currentUser: null,
+      newUser: {
+        name: "",
+        email: "",
+        password: "",
+        isAdmin: false,
+      },
     };
   },
   mounted() {
     // This will be replaced with a call to getUser() when my other pull is merged
     if (localStorage.getItem("user")) {
-      this.currentUser = JSON.parse(localStorage.getItem("user"))
+      this.currentUser = JSON.parse(localStorage.getItem("user"));
     }
   },
   apollo: {
@@ -81,7 +146,7 @@ export default Vue.extend({
     deleteUser(userId: string) {
       this.$apollo.mutate({
         mutation: gql`
-          mutation($userId: ID!) {
+          mutation ($userId: ID!) {
             deleteUser(where: { id: $userId }) {
               id
             }
@@ -101,15 +166,40 @@ export default Vue.extend({
     },
     updateIsAdmin(userId: string, isAdmin: boolean) {
       this.$apollo.mutate({
-       mutation: gql`
-         mutation($userId: ID!, $isAdmin: Boolean!) {
-           updateUser(data: { isAdmin: $isAdmin }, where: { id: $userId }) {
-             id
-             isAdmin
-           }
-         }
-       `,
-       variables: { userId, isAdmin },
+        mutation: gql`
+          mutation ($userId: ID!, $isAdmin: Boolean!) {
+            updateUser(data: { isAdmin: $isAdmin }, where: { id: $userId }) {
+              id
+              isAdmin
+            }
+          }
+        `,
+        variables: { userId, isAdmin },
+      });
+    },
+    createUser() {
+      this.$apollo.mutate({
+        mutation: gql`
+          mutation ($data: UserCreateInput!) {
+            createUser(data: $data) {
+              user {
+                id
+                name
+                email
+                isAdmin
+              }
+            }
+          }
+        `,
+        variables: { data: this.newUser },
+        update: (store, { data: { createUser } }) => {
+          // Read the data from our cache for this query.
+          const data = store.readQuery({ query: USERS });
+          // Adds the user to the cache.
+          data.users.push(createUser.user);
+          // Writes the updated query to the cache.
+          store.writeQuery({ query: USERS, data });
+        },
       });
     }
   },

--- a/client/src/views/Accounts.vue
+++ b/client/src/views/Accounts.vue
@@ -19,12 +19,24 @@
               user.email
             }}</span>
           </div>
-          <button
-            @click="deleteUser(user.id);"
-            class="px-3 py-2 text-sm bg-grey-light hover:bg-red hover:text-white"
-          >
-            Delete
-          </button>
+          <!-- Only edit/delete other users -->
+          <div v-if="currentUser.id !== user.id">
+            <input
+              @change="updateIsAdmin(user.id, $event.target.checked)"
+              type="checkbox"
+              id="is-admin"
+              name="is-admin"
+              v-model="user.isAdmin"
+            >
+            <label for="is-admin" class="ml-2 mr-6">Admin</label>
+            <button
+              @click="deleteUser(user.id);"
+              class="px-3 py-2 text-sm bg-grey-light hover:bg-red hover:text-white"
+            >
+              Delete
+            </button>
+          </div>
+          <div v-else class="text-grey-dark">(You)</div>
         </div>
       </div>
     </div>
@@ -43,6 +55,7 @@ const USERS = gql`
       id
       name
       email
+      isAdmin
     }
   }
 `;
@@ -52,7 +65,14 @@ export default Vue.extend({
   data() {
     return {
       users: [],
+      currentUser: null
     };
+  },
+  mounted() {
+    // This will be replaced with a call to getUser() when my other pull is merged
+    if (localStorage.getItem("user")) {
+      this.currentUser = JSON.parse(localStorage.getItem("user"))
+    }
   },
   apollo: {
     users: USERS,
@@ -79,6 +99,19 @@ export default Vue.extend({
         },
       });
     },
+    updateIsAdmin(userId: string, isAdmin: boolean) {
+      this.$apollo.mutate({
+       mutation: gql`
+         mutation($userId: ID!, $isAdmin: Boolean!) {
+           updateUser(data: { isAdmin: $isAdmin }, where: { id: $userId }) {
+             id
+             isAdmin
+           }
+         }
+       `,
+       variables: { userId, isAdmin },
+      });
+    }
   },
 });
 </script>

--- a/client/src/views/Accounts.vue
+++ b/client/src/views/Accounts.vue
@@ -8,7 +8,10 @@
         <div
           v-for="(user, index) in users"
           :key="user.id"
-          :class="[index !== users.length - 1 && 'border-b', 'py-6']"
+          :class="[
+            index !== users.length - 1 && 'border-b',
+            'py-6 flex justify-between items-center',
+          ]"
         >
           <div class="flex flex-col">
             <span class="leading-normal">{{ user.name }}</span>
@@ -16,6 +19,12 @@
               user.email
             }}</span>
           </div>
+          <button
+            @click="deleteUser(user.id);"
+            class="px-3 py-2 text-sm bg-grey-light hover:bg-red hover:text-white"
+          >
+            Delete
+          </button>
         </div>
       </div>
     </div>
@@ -28,6 +37,16 @@ import Vue from "vue";
 import PageHeader from "@/components/PageHeader.vue";
 import Loader from "@/components/Loader.vue";
 
+const USERS = gql`
+  query users {
+    users {
+      id
+      name
+      email
+    }
+  }
+`;
+
 export default Vue.extend({
   components: { PageHeader, Loader },
   data() {
@@ -36,15 +55,30 @@ export default Vue.extend({
     };
   },
   apollo: {
-    users: gql`
-      query users {
-        users {
-          id
-          name
-          email
-        }
-      }
-    `,
+    users: USERS,
+  },
+  methods: {
+    deleteUser(userId: string) {
+      this.$apollo.mutate({
+        mutation: gql`
+          mutation($userId: ID!) {
+            deleteUser(where: { id: $userId }) {
+              id
+            }
+          }
+        `,
+        variables: { userId },
+        update: (store, { data: { deleteUser } }) => {
+          // Read the data from our cache for this query.
+          const data = store.readQuery({ query: USERS });
+          // Deletes the user from the cache.
+          const index = data.users.findIndex(user => user.id === deleteUser.id);
+          data.users.splice(index, 1);
+          // Writes the updated query to the cache.
+          store.writeQuery({ query: USERS, data });
+        },
+      });
+    },
   },
 });
 </script>

--- a/client/src/views/Accounts.vue
+++ b/client/src/views/Accounts.vue
@@ -1,14 +1,35 @@
 <template>
   <div>
-    <h1>Accounts</h1>
-    <div v-for="user in users" :key="user.id">{{ user.name }}</div>
+    <PageHeader>Accounts</PageHeader>
+    <div v-if="$apollo.loading" class="my-20 text-center"><Loader /></div>
+    <div v-else class="container mx-auto mb-16 px-4">
+      <div class="py-10 text-grey-darker">{{ users.length }} accounts</div>
+      <div class="bg-grey-lightest px-6">
+        <div
+          v-for="(user, index) in users"
+          :key="user.id"
+          :class="[index !== users.length - 1 && 'border-b', 'py-6']"
+        >
+          <div class="flex flex-col">
+            <span class="leading-normal">{{ user.name }}</span>
+            <span class="leading-normal text-sm text-grey-darker">{{
+              user.email
+            }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import gql from "graphql-tag";
+import Vue from "vue";
+import PageHeader from "@/components/PageHeader.vue";
+import Loader from "@/components/Loader.vue";
 
-export default {
+export default Vue.extend({
+  components: { PageHeader, Loader },
   data() {
     return {
       users: [],
@@ -20,9 +41,10 @@ export default {
         users {
           id
           name
+          email
         }
       }
     `,
   },
-};
+});
 </script>

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -72,6 +72,7 @@ export default Vue.extend({
               logIn(email: $email, password: $password) {
                 token
                 user {
+                  id
                   name
                   email
                   isAdmin


### PR DESCRIPTION
## Summary
This pull implements the Accounts page. Admin can create/edit/delete accounts now. Admin can only change `isAdmin`. In order to change name, email or password, the Admin must delete the account and recreate it with the updated info.
 
Closes #114 #119 #117 #116 

### Package Changes
No changes

### Data Model Changes
No changes

### Known Issues
No known issues

## QA
### Test Cases
- [x] Log in (email: `bill@example.com`, password: `password`)
- [x] Go to `/admin/accounts`
- [x] Assert that all accounts are listed with the appropriate info
- [x] Assert that you can toggle "Admin" on other accounts
- [x] Assert that you can't delete or edit your account
- [x] Assert that you can delete other accounts
- [x] Assert that you can create a new account
- [x] Run the e2e tests (`accounts.spec.js`) and assert that they pass (run `npm run test:e2e` in the `client` directory, make sure the client and server are also running)

### User Acceptance Tests
- [x] I updated the [UAT Spreadsheet](https://docs.google.com/spreadsheets/d/1-unNcLQL7Nr2V69aXBpQKMH-Uv7lJhNOD3K-V7wv5Ik/edit?usp=sharing "UAT Spreadsheet") with tests for all proposed feature in this PR.
